### PR TITLE
Add a rust+cc65 devcontainer env

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-1-bullseye
+
+ENV BUILD_DIR="/tmp"
+ENV CC65_VERSION="V2.19"
+
+RUN apt-get update && apt-get install build-essential cc65 -y

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,16 @@
 FROM mcr.microsoft.com/devcontainers/rust:1-1-bullseye
 
-ENV BUILD_DIR="/tmp"
-ENV CC65_VERSION="V2.19"
+ENV BUILD_DIR="/cc65-src"
+ENV CC65_VERSION="2.19"
+ENV CC65_DOWNLOAD_VERSION="V2.19"
+ENV PREFIX="/usr/local"
+ENV CC65_SOURCE_DIR="${BUILD_DIR}/cc65-${CC65_VERSION}"
 
-RUN apt-get update && apt-get install build-essential cc65 -y
+RUN apt-get update && apt-get install build-essential -y && \
+    mkdir -p ${BUILD_DIR} && \
+    cd ${BUILD_DIR} && \
+    wget https://github.com/cc65/cc65/archive/${CC65_DOWNLOAD_VERSION}.tar.gz && \
+    tar xzf ${CC65_DOWNLOAD_VERSION}.tar.gz && \
+    cd cc65* && \
+    make && \
+    make install

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "DB65-Dev-Container",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/jungaretti/features/make:1": {}
+	},
+	// Features to add to the dev container. More info: https://containers.dev/features.	
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"dustypomerleau.rust-syntax",
+				"ms-vscode.cpptools-extension-pack"
+			]
+		}
+	}
+
+	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+	// "mounts": [
+	// 	{
+	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+	// 		"target": "/usr/local/cargo",
+	// 		"type": "volume"
+	// 	}
+	// ]
+
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly


### PR DESCRIPTION
Adds a dev container (see: https://code.visualstudio.com/docs/devcontainers/containers) environment for development.

Based on MS rust container, uses Dockerfile to also include a build of CC65.